### PR TITLE
Update label-pull-request workflow triggers

### DIFF
--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -3,8 +3,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [ main ]
-  push:
-    branches: [ main ]
 
     
 permissions:


### PR DESCRIPTION
Removed push trigger from label-pull-request workflow.

## Summary by Sourcery

CI:
- Remove push trigger from label-pull-request workflow to prevent runs on main pushes